### PR TITLE
Adjust charsets when shelling out

### DIFF
--- a/src/main/java/io/github/soc/directories/Util.java
+++ b/src/main/java/io/github/soc/directories/Util.java
@@ -116,7 +116,7 @@ final class Util {
       buf.append("\\\")\n");
     }
 
-    return runCommands(guidsLength, StandardCharsets.UTF_8,
+    return runCommands(guidsLength, Charset.forName("UTF-8"),
         "powershell.exe",
         "-Command",
         "& {\n" +

--- a/src/main/java/io/github/soc/directories/Util.java
+++ b/src/main/java/io/github/soc/directories/Util.java
@@ -3,6 +3,8 @@ package io.github.soc.directories;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
 final class Util {
@@ -102,7 +104,7 @@ final class Util {
       buf.append(';');
     }
     commands[2] = buf.toString();
-    return runCommands(dirsLength, commands);
+    return runCommands(dirsLength, Charset.defaultCharset(), commands);
   }
 
   static String[] getWinDirs(String... guids) {
@@ -114,10 +116,11 @@ final class Util {
       buf.append("\\\")\n");
     }
 
-    return runCommands(guidsLength,
+    return runCommands(guidsLength, StandardCharsets.UTF_8,
         "powershell.exe",
         "-Command",
         "& {\n" +
+            "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8\n" +
             "Add-Type @\\\"\n" +
             "using System;\n" +
             "using System.Runtime.InteropServices;\n" +
@@ -138,7 +141,7 @@ final class Util {
     );
   }
 
-  private static String[] runCommands(int expectedResultLines, String... commands) {
+  private static String[] runCommands(int expectedResultLines, Charset charset, String... commands) {
     final ProcessBuilder processBuilder = new ProcessBuilder(commands);
     Process process;
     try {
@@ -148,7 +151,7 @@ final class Util {
     }
 
     String[] results = new String[expectedResultLines];
-    BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+    BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), charset));
     try {
       for (int i = 0; i < expectedResultLines; i++) {
         String line = reader.readLine();


### PR DESCRIPTION
This PR makes the powershell command emit utf-8 on Windows. This fixes https://github.com/soc/directories-jvm/issues/19 in my tests.

This also makes explicit the use of the default charset when reading the output of the `xdg-user-dir` command (not sure how to force it to emit utf-8…)