### PR TITLE
Correction of the README and some minor sonar complaints

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,15 +144,15 @@ that have been defined according to the conventions of the operating system the 
 
 ### `ProjectDirectories`
 
-The intended use-case for `BaseDirectories` is to compute the location of cache, config or data folders for your own application or project,
+The intended use-case for `ProjectDirectories` is to compute the location of cache, config or data folders for your own application or project,
 which are derived from the standard directories.
 
 | Field name     | Value on Linux / BSD                                                       | Value on Windows                                         | Value on macOS                                       |
 | -------------- | -------------------------------------------------------------------------- | -------------------------------------------------------- | ---------------------------------------------------- |
 | `cacheDir`     | `$XDG_CACHE_HOME`/`<project_path>` or `$HOME`/.cache/`<project_path>`      | `{FOLDERID_LocalApplicationData}`/`<project_path>`/cache | `$HOME`/Library/Caches/`<project_path>`              |
-| `configDir`    | `$XDG_CONFIG_HOME`/`<project_path>`  or `$HOME`/.config/`<project_path>`   | `{FOLDERID_ApplicationData}`/`<project_path>`            | `$HOME`/Library/Preferences/`<project_path>`         |
-| `dataDir`      | `$XDG_DATA_HOME`/`<project_path>` or `$HOME`/.local/share/`<project_path>` | `{FOLDERID_ApplicationData}`/`<project_path>`            | `$HOME`/Library/Application Support/`<project_path>` |
-| `dataLocalDir` | `$XDG_DATA_HOME`/`<project_path>` or `$HOME`/.local/share/`<project_path>` | `{FOLDERID_LocalApplicationData}`/`<project_path>`       | `$HOME`/Library/Application Support/`<project_path>` |
+| `configDir`    | `$XDG_CONFIG_HOME`/`<project_path>`  or `$HOME`/.config/`<project_path>`   | `{FOLDERID_ApplicationData}`/`<project_path>`/config     | `$HOME`/Library/Preferences/`<project_path>`         |
+| `dataDir`      | `$XDG_DATA_HOME`/`<project_path>` or `$HOME`/.local/share/`<project_path>` | `{FOLDERID_ApplicationData}`/`<project_path>`/data       | `$HOME`/Library/Application Support/`<project_path>` |
+| `dataLocalDir` | `$XDG_DATA_HOME`/`<project_path>` or `$HOME`/.local/share/`<project_path>` | `{FOLDERID_LocalApplicationData}`/`<project_path>`/data  | `$HOME`/Library/Application Support/`<project_path>` |
 | `runtimeDir`   | `$XDG_RUNTIME_DIR`/`<project_path>`                                        | `null`                                                   | `null`                                               |
 
 The specific value of `<project_path>` is computed by the

--- a/src/main/java/io/github/soc/directories/Util.java
+++ b/src/main/java/io/github/soc/directories/Util.java
@@ -4,7 +4,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
 final class Util {
@@ -70,8 +69,9 @@ final class Util {
       return buf.toString();
     } else if (!arg1Slash && !slashArg2) {
       return arg1 + '/' + arg2;
-    } else
+    } else {
       return arg1 + arg2;
+    }
   }
 
   static String linuxRuntimeDir(String path) {

--- a/src/test/java/io/github/soc/directories/UtilTest.java
+++ b/src/test/java/io/github/soc/directories/UtilTest.java
@@ -60,7 +60,7 @@ public final class UtilTest {
     final String inputOrga = "Foo Bar";
     final String inputProj = "";
     final String actual = Util.macOSApplicationPath(inputQual, inputOrga, inputProj);
-    assertEquals(actual, "Foo-Bar");
+    assertEquals("Foo-Bar", actual);
   }
 
   @Test
@@ -69,7 +69,7 @@ public final class UtilTest {
     final String inputOrga = "";
     final String inputProj = "Baz Qux";
     final String actual = Util.macOSApplicationPath(inputQual, inputOrga, inputProj);
-    assertEquals(actual, "Baz-Qux");
+    assertEquals("Baz-Qux", actual);
   }
 
   @Test
@@ -78,7 +78,7 @@ public final class UtilTest {
     final String inputOrga = "Foo Bar";
     final String inputProj = "Baz Qux";
     final String actual = Util.macOSApplicationPath(inputQual, inputOrga, inputProj);
-    assertEquals(actual, "Foo-Bar.Baz-Qux");
+    assertEquals("Foo-Bar.Baz-Qux", actual);
   }
 
   @Test
@@ -87,7 +87,7 @@ public final class UtilTest {
     final String inputOrga = "Foo Bar";
     final String inputProj = "";
     final String actual = Util.macOSApplicationPath(inputQual, inputOrga, inputProj);
-    assertEquals(actual, "uk.co.Foo-Bar");
+    assertEquals("uk.co.Foo-Bar", actual);
   }
 
   @Test
@@ -96,7 +96,7 @@ public final class UtilTest {
     final String inputOrga = "";
     final String inputProj = "Baz Qux";
     final String actual = Util.macOSApplicationPath(inputQual, inputOrga, inputProj);
-    assertEquals(actual, "uk.co.Baz-Qux");
+    assertEquals("uk.co.Baz-Qux", actual);
   }
 
   @Test
@@ -105,7 +105,7 @@ public final class UtilTest {
     final String inputOrga = "Foo Bar";
     final String inputProj = "Baz Qux";
     final String actual = Util.macOSApplicationPath(inputQual, inputOrga, inputProj);
-    assertEquals(actual, "uk.co.Foo-Bar.Baz-Qux");
+    assertEquals("uk.co.Foo-Bar.Baz-Qux", actual);
   }
 
   @Test
@@ -114,7 +114,7 @@ public final class UtilTest {
     final String inputOrga = " Foo  Bar ";
     final String inputProj = "  Baz Qux  ";
     final String actual = Util.macOSApplicationPath(inputQual, inputOrga, inputProj);
-    assertEquals(actual, "uk.co.Foo-Bar.Baz-Qux");
+    assertEquals("uk.co.Foo-Bar.Baz-Qux", actual);
   }
 
   @Test
@@ -123,7 +123,7 @@ public final class UtilTest {
     final String inputOrga = "Foo Bar";
     final String inputProj = "";
     final String actual = Util.windowsApplicationPath(inputQual, inputOrga, inputProj);
-    assertEquals(actual, "Foo Bar");
+    assertEquals("Foo Bar", actual);
   }
 
   @Test
@@ -132,7 +132,7 @@ public final class UtilTest {
     final String inputOrga = "";
     final String inputProj = "Baz Qux";
     final String actual = Util.windowsApplicationPath(inputQual, inputOrga, inputProj);
-    assertEquals(actual, "Baz Qux");
+    assertEquals("Baz Qux", actual);
   }
 
   @Test
@@ -141,7 +141,7 @@ public final class UtilTest {
     final String inputOrga = "Foo Bar";
     final String inputProj = "Baz Qux";
     final String actual = Util.windowsApplicationPath(inputQual, inputOrga, inputProj);
-    assertEquals(actual, "Foo Bar\\Baz Qux");
+    assertEquals("Foo Bar\\Baz Qux", actual);
   }
 
   @Test
@@ -150,7 +150,7 @@ public final class UtilTest {
     final String inputOrga = "Foo Bar";
     final String inputProj = "";
     final String actual = Util.windowsApplicationPath(inputQual, inputOrga, inputProj);
-    assertEquals(actual, "Foo Bar");
+    assertEquals("Foo Bar", actual);
   }
 
   @Test
@@ -159,7 +159,7 @@ public final class UtilTest {
     final String inputOrga = "";
     final String inputProj = "Baz Qux";
     final String actual = Util.windowsApplicationPath(inputQual, inputOrga, inputProj);
-    assertEquals(actual, "Baz Qux");
+    assertEquals("Baz Qux", actual);
   }
 
   @Test
@@ -168,6 +168,6 @@ public final class UtilTest {
     final String inputOrga = "Foo Bar";
     final String inputProj = "Baz Qux";
     final String actual = Util.windowsApplicationPath(inputQual, inputOrga, inputProj);
-    assertEquals(actual, "Foo Bar\\Baz Qux");
+    assertEquals("Foo Bar\\Baz Qux", actual);
   }
 }


### PR DESCRIPTION
Correction of the description of ProjectDirectories in README.md.
Removed the unused import of StandardCharsets not available in Java 6.
Added brackets in last else of ensureSingleSlash for homogeneity.
Changed order of parameters in assertEquals to follow junit semantic.