### PR TITLE
add Solaris support

### DIFF
--- a/src/main/java/io/github/soc/directories/BaseDirectories.java
+++ b/src/main/java/io/github/soc/directories/BaseDirectories.java
@@ -223,6 +223,7 @@ public final class BaseDirectories {
     switch (operatingSystem) {
       case LIN:
       case BSD:
+      case SOLARIS:
         homeDir       = System.getProperty("user.home");
         cacheDir      = defaultIfNullOrEmpty(System.getenv("XDG_CACHE_HOME"),  homeDir, "/.cache");
         configDir     = defaultIfNullOrEmpty(System.getenv("XDG_CONFIG_HOME"), homeDir, "/.config");

--- a/src/main/java/io/github/soc/directories/ProjectDirectories.java
+++ b/src/main/java/io/github/soc/directories/ProjectDirectories.java
@@ -202,6 +202,7 @@ public final class ProjectDirectories {
     switch (operatingSystem) {
       case LIN:
       case BSD:
+      case SOLARIS:
         homeDir      = System.getProperty("user.home");
         cacheDir     = defaultIfNullOrEmptyExtended(System.getenv("XDG_CACHE_HOME"),  path, homeDir + "/.cache/",       path);
         configDir    = defaultIfNullOrEmptyExtended(System.getenv("XDG_CONFIG_HOME"), path, homeDir + "/.config/",      path);
@@ -258,6 +259,7 @@ public final class ProjectDirectories {
     switch (operatingSystem) {
       case LIN:
       case BSD:
+      case SOLARIS:
         path = trimLowercaseReplaceWhitespace(application, "", true);
         break;
       case MAC:

--- a/src/main/java/io/github/soc/directories/UserDirectories.java
+++ b/src/main/java/io/github/soc/directories/UserDirectories.java
@@ -302,6 +302,7 @@ public final class UserDirectories {
     switch (operatingSystem) {
       case LIN:
       case BSD:
+      case SOLARIS:
         String[] userDirs = getXDGUserDirs("MUSIC", "DESKTOP", "DOCUMENTS", "DOWNLOAD", "PICTURES", "PUBLICSHARE", "TEMPLATES", "VIDEOS");
         homeDir       = System.getProperty("user.home");
         audioDir      = userDirs[0];

--- a/src/main/java/io/github/soc/directories/Util.java
+++ b/src/main/java/io/github/soc/directories/Util.java
@@ -18,6 +18,7 @@ final class Util {
   static final char MAC = 'm';
   static final char WIN = 'w';
   static final char BSD = 'b';
+  static final char SOLARIS = 's';
 
   static {
     final String os = operatingSystemName.toLowerCase(Locale.ROOT);
@@ -29,6 +30,8 @@ final class Util {
       operatingSystem = WIN;
     else if (os.contains("bsd"))
       operatingSystem = BSD;
+    else if (os.contains("sunos"))
+      operatingSystem = SOLARIS;
     else
       throw new UnsupportedOperatingSystemException("directories are not supported on " + operatingSystemName);
   }


### PR DESCRIPTION
Added Solaris support. Testing on Solaris is difficult because sbt depends directories-jvm and build/test of directories-jvm depends on sbt which do not yet work on Solaris because depends on directories-jvm. Chicken-egg problem. 

Closes #23 