### PR TITLE
Handle new way of escaping quotes on Windows

### DIFF
--- a/src/main/java/io/github/soc/directories/Util.java
+++ b/src/main/java/io/github/soc/directories/Util.java
@@ -113,21 +113,18 @@ final class Util {
   static String[] getWinDirs(String... guids) {
 
     // See https://www.oracle.com/technetwork/java/javase/8u231-relnotes-5592812.html#JDK-8221858
-    // If a security manager is set, ProcessBuilder should safely escape things.
-    final boolean doubleEscapeQuotes = System.getSecurityManager() == null;
+    // Vague attempt at replicating the logic followed by ProcessBuilder, just so that the first
+    // attempt succeeds and only one command needs to be run.
+    final String prop = System.getProperty("jdk.lang.Process.allowAmbiguousCommands");
+    final boolean doubleEscapeQuotes = prop == null ? System.getSecurityManager() == null : !"false".equalsIgnoreCase(prop);
     final String[] initialResult = getWinDirs(doubleEscapeQuotes, guids);
 
-    boolean hasNonNull = initialResult.length == 0;
     for (String s : initialResult) {
-      if (s != null) {
-        hasNonNull = true;
-        break;
-      }
+      if (s != null)
+        return initialResult;
     }
 
-    if (hasNonNull)
-      return initialResult;
-
+    // First attempt failed, let's try to escape differently.
     return getWinDirs(!doubleEscapeQuotes, guids);
   }
 

--- a/src/main/java/io/github/soc/directories/Util.java
+++ b/src/main/java/io/github/soc/directories/Util.java
@@ -111,12 +111,37 @@ final class Util {
   }
 
   static String[] getWinDirs(String... guids) {
+
+    String[] escapedResult = getWinDirs(true, guids);
+
+    boolean hasNonNull = escapedResult.length == 0;
+    for (String s : escapedResult) {
+      if (s != null) {
+        hasNonNull = true;
+        break;
+      }
+    }
+
+    if (hasNonNull)
+      return escapedResult;
+
+    return getWinDirs(false, guids);
+  }
+
+  static String[] getWinDirs(boolean escapeQuotes, String... guids) {
+
+    // Deal with legacy or safe handling of quotes by the JDK.
+    // Safe handling may be enabled for JDKs >= 1.8.0_231, under some conditions.
+    // See https://www.oracle.com/technetwork/java/javase/8u231-relnotes-5592812.html#JDK-8221858
+    // or https://github.com/AdoptOpenJDK/openjdk-jdk8u/commit/048eb42afa11ac217dcdb690d5b266fcb910771f
+    final String q = escapeQuotes ? "\\\"" : "\"";
+
     int guidsLength = guids.length;
     StringBuilder buf = new StringBuilder(guidsLength * 68);
     for (int i = 0; i < guidsLength; i++) {
-      buf.append("[Dir]::GetKnownFolderPath(\\\"");
+      buf.append("[Dir]::GetKnownFolderPath(" + q);
       buf.append(guids[i]);
-      buf.append("\\\")\n");
+      buf.append(q + ")\n");
     }
 
     return runCommands(guidsLength, Charset.forName("UTF-8"),
@@ -124,21 +149,21 @@ final class Util {
         "-Command",
         "& {\n" +
             "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8\n" +
-            "Add-Type @\\\"\n" +
+            "Add-Type @" + q + "\n" +
             "using System;\n" +
             "using System.Runtime.InteropServices;\n" +
             "public class Dir {\n" +
-            "   [DllImport(\\\"shell32.dll\\\")]\n" +
+            "   [DllImport(" + q + "shell32.dll" + q + ")]\n" +
             "   private static extern int SHGetKnownFolderPath([MarshalAs(UnmanagedType.LPStruct)] Guid rfid, uint dwFlags, IntPtr hToken, out IntPtr pszPath);\n" +
             "   public static string GetKnownFolderPath(string rfid) {\n" +
             "       IntPtr pszPath;\n" +
-            "       if (SHGetKnownFolderPath(new Guid(rfid), 0, IntPtr.Zero, out pszPath) != 0) return \\\"\\\";\n" +
+            "       if (SHGetKnownFolderPath(new Guid(rfid), 0, IntPtr.Zero, out pszPath) != 0) return " + q + q + ";\n" +
             "       string path = Marshal.PtrToStringUni(pszPath);\n" +
             "       Marshal.FreeCoTaskMem(pszPath);\n" +
             "       return path;\n" +
             "   }\n" +
             "}\n" +
-            "\\\"@\n" +
+            q + "@\n" +
             buf.toString() +
             "}"
     );

--- a/src/main/java/io/github/soc/directories/Util.java
+++ b/src/main/java/io/github/soc/directories/Util.java
@@ -112,10 +112,13 @@ final class Util {
 
   static String[] getWinDirs(String... guids) {
 
-    String[] escapedResult = getWinDirs(true, guids);
+    // See https://www.oracle.com/technetwork/java/javase/8u231-relnotes-5592812.html#JDK-8221858
+    // If a security manager is set, ProcessBuilder should safely escape things.
+    final boolean doubleEscapeQuotes = System.getSecurityManager() == null;
+    final String[] initialResult = getWinDirs(doubleEscapeQuotes, guids);
 
-    boolean hasNonNull = escapedResult.length == 0;
-    for (String s : escapedResult) {
+    boolean hasNonNull = initialResult.length == 0;
+    for (String s : initialResult) {
       if (s != null) {
         hasNonNull = true;
         break;
@@ -123,18 +126,18 @@ final class Util {
     }
 
     if (hasNonNull)
-      return escapedResult;
+      return initialResult;
 
-    return getWinDirs(false, guids);
+    return getWinDirs(!doubleEscapeQuotes, guids);
   }
 
-  static String[] getWinDirs(boolean escapeQuotes, String... guids) {
+  static String[] getWinDirs(boolean doubleEscapeQuotes, String... guids) {
 
     // Deal with legacy or safe handling of quotes by the JDK.
     // Safe handling may be enabled for JDKs >= 1.8.0_231, under some conditions.
     // See https://www.oracle.com/technetwork/java/javase/8u231-relnotes-5592812.html#JDK-8221858
     // or https://github.com/AdoptOpenJDK/openjdk-jdk8u/commit/048eb42afa11ac217dcdb690d5b266fcb910771f
-    final String q = escapeQuotes ? "\\\"" : "\"";
+    final String q = doubleEscapeQuotes ? "\\\"" : "\"";
 
     int guidsLength = guids.length;
     StringBuilder buf = new StringBuilder(guidsLength * 68);


### PR DESCRIPTION
Fixes https://github.com/soc/directories-jvm/issues/26.

This first tries to get the directories with the former / legacy handling of quotes (using `"\\\""` for a quote). If we get only `null`s, we try with the new way of handling quotes (using just `"\""`). Both ways need to be tried, as only one of them works in a given context.