### PR TITLE
Add reflect-config.json for GraalVM native-image

### DIFF
--- a/src/main/resources/META-INF/native-image/io.github.soc/directories/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/io.github.soc/directories/reflect-config.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name" : "java.util.Base64",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredClasses" : true,
+    "allPublicClasses" : true
+  },
+  {
+    "name" : "java.util.Base64$Encoder",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredClasses" : true,
+    "allPublicClasses" : true
+  }
+]


### PR DESCRIPTION
This file makes it easier for directories-jvm users to generate GraalVM images. It marks `java.util.Base64` and `java.util.Base64$Encoder` as possibly obtained / inspected by reflection, as [directories-jvm does](https://github.com/soc/directories-jvm/blob/3838ce7eedb41f0191a39b6fa7b09029b771a0b9/src/main/java/io/github/soc/directories/Util.java#L171-L172) now.

If it's not done by directories-jvm, users have to
- first discover, after a possibly lengthy image generation, that these classes are reflected upon, and
- add these to their GraalVM config files or command-line options.

Whereas if directories-jvm ships that file, they don't have to think about that.

I didn't add tests right now, but if I take the time to look into https://github.com/soc/directories-jvm/issues/32, maybe a native binary could be generated for that CLI, which would ensure there's no regression in `reflect-config.json`.

The additional settings could be possibly narrowed... I didn't take the time to do it.